### PR TITLE
[Fix/Feat] 금융 정보 화면 UI UX 개선 및 퀴즈 시스템 로직/멀티 계정 지원 구현

### DIFF
--- a/frontend/app/src/main/java/com/moneybuddy/moneylog/common/RetrofitClient.java
+++ b/frontend/app/src/main/java/com/moneybuddy/moneylog/common/RetrofitClient.java
@@ -20,8 +20,8 @@ public final class RetrofitClient {
     private static volatile Retrofit instance;
 
     // 필요 시 교체
-    private static final String BASE_URL_DEBUG   = "http://172.21.170.228:8080/";
-    private static final String BASE_URL_RELEASE = "http://172.21.170.228:8080/";
+    private static final String BASE_URL_DEBUG   = "http://10.0.2.2:8080/";
+    private static final String BASE_URL_RELEASE = "http://10.0.2.2:8080/";
 
     private RetrofitClient() {}
 

--- a/frontend/app/src/main/java/com/moneybuddy/moneylog/common/RetrofitClient.java
+++ b/frontend/app/src/main/java/com/moneybuddy/moneylog/common/RetrofitClient.java
@@ -20,8 +20,8 @@ public final class RetrofitClient {
     private static volatile Retrofit instance;
 
     // 필요 시 교체
-    private static final String BASE_URL_DEBUG   = "http://10.0.2.2:8080/";
-    private static final String BASE_URL_RELEASE = "http://10.0.2.2:8080/";
+    private static final String BASE_URL_DEBUG   = "http://172.21.170.228:8080/";
+    private static final String BASE_URL_RELEASE = "http://172.21.170.228:8080/";
 
     private RetrofitClient() {}
 

--- a/frontend/app/src/main/java/com/moneybuddy/moneylog/finance/activity/FinanceInfoActivity.java
+++ b/frontend/app/src/main/java/com/moneybuddy/moneylog/finance/activity/FinanceInfoActivity.java
@@ -49,6 +49,7 @@ public class FinanceInfoActivity extends AppCompatActivity {
     private TabLayout tabLayout;
     private View sectionHealthScore, sectionCardNews, sectionQuiz;
     private LinearLayout sectionYouthPolicy;
+    private View sectionYouthPolicyTitle;
     private com.google.android.material.button.MaterialButton btnImproveScore;
     private ViewPager2 viewPagerCardNews;
     private CardNewsAdapter cardNewsAdapter;
@@ -97,8 +98,9 @@ public class FinanceInfoActivity extends AppCompatActivity {
 
         sectionHealthScore = findViewById(R.id.section_health_score);
         sectionCardNews = findViewById(R.id.tv_card_news_title);
-        sectionQuiz = findViewById(R.id.section_quiz);
+        sectionQuiz = findViewById(R.id.tv_quiz_title);
         sectionYouthPolicy = (LinearLayout) findViewById(R.id.section_youth_policy);
+        sectionYouthPolicyTitle = findViewById(R.id.tv_youth_title);
         btnImproveScore = findViewById(R.id.btn_improve_score);
 
         viewPagerCardNews = findViewById(R.id.view_pager_card_news);
@@ -212,7 +214,7 @@ public class FinanceInfoActivity extends AppCompatActivity {
                         scrollToView(sectionQuiz);
                         break;
                     case 3:
-                        scrollToView(sectionYouthPolicy);
+                        scrollToView(sectionYouthPolicyTitle);
                         break;
                 }
             }

--- a/frontend/app/src/main/java/com/moneybuddy/moneylog/finance/activity/FinanceInfoActivity.java
+++ b/frontend/app/src/main/java/com/moneybuddy/moneylog/finance/activity/FinanceInfoActivity.java
@@ -41,8 +41,6 @@ import retrofit2.Response;
 
 public class FinanceInfoActivity extends AppCompatActivity {
     private static final String TAG = "FinanceInfoActivity";
-
-    // UI 요소
     private ImageButton btnBack;
     private NestedScrollView nestedScrollView;
     private FloatingActionButton fabScrollToTop;
@@ -53,16 +51,14 @@ public class FinanceInfoActivity extends AppCompatActivity {
     private com.google.android.material.button.MaterialButton btnImproveScore;
     private ViewPager2 viewPagerCardNews;
     private CardNewsAdapter cardNewsAdapter;
-
-    // 퀴즈 관련 UI 요소
     private TextView tvQuizQuestion;
     private ImageButton btnQuizO, btnQuizX;
-
-    // 네트워크 및 데이터
+    private LinearLayout layoutQuizActive;
+    private LinearLayout layoutQuizCompleted;
+    private TextView tvCompletedQuizQuestion;
+    private TextView tvCompletedQuizExplanation;
     private ApiService apiService;
     private Long currentQuizId;
-
-    // FinanceInfoActivity.java 내부
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -76,15 +72,15 @@ public class FinanceInfoActivity extends AppCompatActivity {
             return insets;
         });
 
-        // 1. apiService를 가장 먼저 초기화하여 NullPointerException을 원천적으로 방지합니다.
+        // apiService 초기화
         apiService = RetrofitClient.api(this);
 
-        // 2. UI 요소들을 초기화하고 리스너를 설정합니다.
+        // UI 요소 초기화, 리스너 설정
         initializeViews();
         setupClickListeners();
         setupCardNewsSection();
 
-        // 3. 필요한 데이터를 각각 한 번씩 로딩합니다. (중복 호출 제거)
+        // 데이터를 로딩
         loadCardNewsData();
         loadTodayQuiz();
         loadYouthPolicies();
@@ -108,6 +104,11 @@ public class FinanceInfoActivity extends AppCompatActivity {
         tvQuizQuestion = findViewById(R.id.tv_quiz_question);
         btnQuizO = findViewById(R.id.btn_quiz_o);
         btnQuizX = findViewById(R.id.btn_quiz_x);
+
+        layoutQuizActive = findViewById(R.id.section_quiz);
+        layoutQuizCompleted = findViewById(R.id.section_quiz_completed);
+        tvCompletedQuizQuestion = findViewById(R.id.tv_completed_quiz_question);
+        tvCompletedQuizExplanation = findViewById(R.id.tv_completed_quiz_explanation);
     }
 
     private void loadYouthPolicies() {
@@ -188,7 +189,7 @@ public class FinanceInfoActivity extends AppCompatActivity {
             } else {
                 Toast.makeText(this, "연결된 웹사이트가 없습니다.", Toast.LENGTH_SHORT).show();
             }
-            dialog.dismiss(); // 웹사이트로 이동 후 다이얼로그 닫음
+            dialog.dismiss();
         });
 
         dialog.show();
@@ -308,6 +309,15 @@ public class FinanceInfoActivity extends AppCompatActivity {
                 if (response.isSuccessful() && response.body() != null) {
                     QuizResultResponse result = response.body();
                     showResultDialog(result.isCorrect(), result.getExplanation());
+
+                    String originalQuestion = tvQuizQuestion.getText().toString();
+                    String explanation = result.getExplanation();
+
+                    tvCompletedQuizQuestion.setText("오늘 푼 문제: " + originalQuestion);
+                    tvCompletedQuizExplanation.setText("해설: " + explanation);
+
+                    layoutQuizActive.setVisibility(View.GONE);
+                    layoutQuizCompleted.setVisibility(View.VISIBLE);
                 } else {
                     Toast.makeText(FinanceInfoActivity.this, "정답 제출에 실패했습니다.", Toast.LENGTH_SHORT).show();
                     Log.e(TAG, "Answer Submit Response Error: " + response.code());

--- a/frontend/app/src/main/java/com/moneybuddy/moneylog/finance/dto/response/QuizResultResponse.java
+++ b/frontend/app/src/main/java/com/moneybuddy/moneylog/finance/dto/response/QuizResultResponse.java
@@ -3,7 +3,7 @@ package com.moneybuddy.moneylog.finance.dto.response;
 import com.google.gson.annotations.SerializedName;
 
 public class QuizResultResponse {
-    @SerializedName("correct")
+    @SerializedName("isCorrect")
     private boolean isCorrect;
 
     @SerializedName("explanation")

--- a/frontend/app/src/main/res/layout/activity_finance_info.xml
+++ b/frontend/app/src/main/res/layout/activity_finance_info.xml
@@ -12,7 +12,9 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:background="@android:color/transparent"
-        app:elevation="0dp">
+        app:elevation="0dp"
+        app:liftOnScroll="false"
+        android:stateListAnimator="@null">
 
         <androidx.appcompat.widget.Toolbar
             android:id="@+id/toolbar"
@@ -59,7 +61,8 @@
             app:tabMode="fixed"
             app:tabGravity="fill"
             app:tabTextColor="#888888"
-            app:tabSelectedTextColor="#333333">
+            app:tabSelectedTextColor="#333333"
+            app:tabRippleColor="#33A8B9A0">
 
             <com.google.android.material.tabs.TabItem
                 android:id="@+id/tab_health_score"

--- a/frontend/app/src/main/res/layout/activity_finance_info.xml
+++ b/frontend/app/src/main/res/layout/activity_finance_info.xml
@@ -216,7 +216,8 @@
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:orientation="vertical"
-                    android:padding="16dp">
+                    android:padding="16dp"
+                    android:visibility="visible">
 
                     <TextView
                         android:layout_width="match_parent"
@@ -280,8 +281,58 @@
                             </LinearLayout>
                         </LinearLayout>
                     </com.google.android.material.card.MaterialCardView>
+                    </LinearLayout>
+                <LinearLayout
+                    android:id="@+id/section_quiz_completed"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="vertical"
+                    android:padding="16dp"
+                    android:visibility="gone">
+
+                    <TextView
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:text="오늘은 퀴즈를 풀었습니다!"
+                        android:textColor="@android:color/black"
+                        android:textSize="18sp"
+                        android:textStyle="bold"
+                        android:gravity="center_horizontal"
+                        android:layout_marginBottom="8dp"/> <com.google.android.material.card.MaterialCardView
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    app:cardCornerRadius="16dp"
+                    app:cardElevation="0dp"
+                    android:backgroundTint="@android:color/white">
+
+                    <LinearLayout
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:orientation="vertical"
+                        android:paddingVertical="24dp"
+                        android:paddingHorizontal="16dp">
+
+                        <TextView
+                            android:id="@+id/tv_completed_quiz_question"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:text="오늘 푼 문제: ..."
+                            android:textColor="@android:color/black"
+                            android:textSize="16sp"
+                            android:layout_marginBottom="8dp"/>
+
+                        <TextView
+                            android:id="@+id/tv_completed_quiz_explanation"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:text="해설: ..."
+                            android:textColor="#333333"
+                            android:textSize="16sp"
+                            android:lineSpacingExtra="4dp"/>
+                    </LinearLayout>
+                </com.google.android.material.card.MaterialCardView>
                 </LinearLayout>
-            </com.google.android.material.card.MaterialCardView>
+                </com.google.android.material.card.MaterialCardView>
 
             <TextView
                 android:id="@+id/tv_youth_title"


### PR DESCRIPTION
### 변경 사항

1. 퀴즈 시스템

- 정답 처리 로직 버그 수정:
    - 사용자가 퀴즈의 정답을 맞혔음에도 불구하고 오답으로 처리되어 표시되는 로직 오류 수정
- 오늘의 퀴즈 완료 상태 UI 및 로직 구현:
    - 퀴즈를 풀고 난 후, 사용자가 완료했음을 인지할 수 있도록 완료 상태 UI 구현
    - 앱을 재시작하거나 화면을 이동해도 완료 상태가 유지되도록 내부 저장 로직 구현
- 멀티 계정 지원 (사용자별 상태 분리):
    - User ID를 기반으로 퀴즈 풀이 상태를 독립적으로 저장하도록 구조 변경

2. 금융 정보 화면

- 탭 클릭 시 스크롤 동작 수정:
    - 금융 정보 화면의 탭 레이아웃에서 특정 카테고리 탭을 클릭했을 때, 해당 콘텐츠 위치로 스크롤 되도록 수정
- 시각 효과 및 리플 색상 개선:
    - 화면의 가독성을 해치던 불필요한 보라색 시각 효과 제거
    - 탭 클릭 시 발생하는 리플 효과 색상 수정